### PR TITLE
Do not assume simpleRouting is enabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,8 @@ paths: {
 },
 ```
 
+Then finally, so the UI can read the swagger data, ensure that the route `GET /api/swagger` is configured to point to the `swagger` action.
+
 For more information, checkout the [Actionhero docs](http://www.actionherojs.com/docs/core/plugins.html).
 
 ## Overview

--- a/public/swagger.html
+++ b/public/swagger.html
@@ -28,7 +28,7 @@
       // Might need to consider local storage or something to ease this.  Or even dynamically 
       // generate this file on start-up so we won't have to rely on this detection.
       var d = $.Deferred();
-      var url = '/api?action=swagger&secure=' + (window.location.protocol.indexOf('https') >= 0);
+      var url = '/api/swagger&secure=' + (window.location.protocol.indexOf('https') >= 0);
       $.get(url, function(data) {
         if(data.error) {
           url = '/api/swagger&secure=' + (window.location.protocol.indexOf('https') >= 0);

--- a/public/swagger.html
+++ b/public/swagger.html
@@ -39,7 +39,7 @@
           d.resolve(url);
         }
       }).fail(function() {
-        url = '/api/swagger&secure=' + (window.location.protocol.indexOf('https') >= 0);
+        url = '/api/swagger?secure=' + (window.location.protocol.indexOf('https') >= 0);
         d.resolve(url);
       });
       d.promise().then(function(url) {

--- a/public/swagger.html
+++ b/public/swagger.html
@@ -28,10 +28,10 @@
       // Might need to consider local storage or something to ease this.  Or even dynamically 
       // generate this file on start-up so we won't have to rely on this detection.
       var d = $.Deferred();
-      var url = '/api/swagger&secure=' + (window.location.protocol.indexOf('https') >= 0);
+      var url = '/api/swagger?secure=' + (window.location.protocol.indexOf('https') >= 0);
       $.get(url, function(data) {
         if(data.error) {
-          url = '/api/swagger&secure=' + (window.location.protocol.indexOf('https') >= 0);
+          url = '/api/swagger?secure=' + (window.location.protocol.indexOf('https') >= 0);
           $.get(url, function(data) {
             d.resolve(url);
           });

--- a/public/swagger/index.html
+++ b/public/swagger/index.html
@@ -1,0 +1,1 @@
+../swagger.html


### PR DESCRIPTION
We should enforce that a route for swagger is enabled rather than assume `simpleRouting` is enabled.
